### PR TITLE
Fix pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "A Xircuits component library for XGBoost!"
 authors = [{ name = "XpressAI", email = "eduardo@xpress.ai" }]
 license = "Apache-2.0"
-readme = "readme.md"
+readme = "README.md"
 repository = "https://github.com/XpressAI/xai-xgboost"
 keywords = ["xircuits", "machine learning", "xgboost"]
 


### PR DESCRIPTION
# Description
This PR fixes metadata issues in the `pyproject.toml` of **xai-xgboost**:

- Corrected `readme` casing to `README.md`.
- Verified `default_example_path` points to a valid example.